### PR TITLE
Implement order and order item CRUD with JWT user linkage

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -37,6 +37,10 @@ builder.Services.AddScoped<IProductRepository, ProductRepository>();
 builder.Services.AddScoped<IProductService, ProductService>();
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IAuthService, AuthService>();
+builder.Services.AddScoped<IOrderRepository, OrderRepository>();
+builder.Services.AddScoped<IOrderItemRepository, OrderItemRepository>();
+builder.Services.AddScoped<IOrderService, OrderService>();
+builder.Services.AddScoped<IOrderItemService, OrderItemService>();
 
 var key = Encoding.UTF8.GetBytes(builder.Configuration["Jwt:Key"]!);
 

--- a/src/EcommerceAPI.API/Controllers/OrderItemsController.cs
+++ b/src/EcommerceAPI.API/Controllers/OrderItemsController.cs
@@ -1,0 +1,98 @@
+using ecommerceAPI.src.EcommerceAPI.Application.DTOs;
+using ecommerceAPI.src.EcommerceAPI.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace ecommerceAPI.src.EcommerceAPI.API.Controllers
+{
+    [ApiController]
+    [Route("api/orders/{orderId}/items")]
+    [Authorize]
+    public class OrderItemsController : ControllerBase
+    {
+        private readonly IOrderItemService _orderItemService;
+
+        public OrderItemsController(IOrderItemService orderItemService)
+        {
+            _orderItemService = orderItemService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetItems(Guid orderId)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var items = await _orderItemService.GetItemsByOrderIdAsync(orderId, userId);
+            return Ok(items);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetItem(Guid orderId, Guid id)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var item = await _orderItemService.GetItemByIdAsync(id, userId);
+            if (item == null)
+            {
+                return NotFound();
+            }
+            return Ok(item);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> AddItem(Guid orderId, [FromBody] CreateOrderItemDto orderItemDto)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var createdItem = await _orderItemService.AddItemAsync(orderId, userId, orderItemDto);
+            return CreatedAtAction(nameof(GetItem), new { orderId = orderId, id = createdItem.Id }, createdItem);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateItem(Guid orderId, Guid id, [FromBody] UpdateOrderItemDto orderItemDto)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var updated = await _orderItemService.UpdateItemAsync(id, userId, orderItemDto);
+            if (!updated)
+            {
+                return NotFound();
+            }
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteItem(Guid orderId, Guid id)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var deleted = await _orderItemService.DeleteItemAsync(id, userId);
+            if (!deleted)
+            {
+                return NotFound();
+            }
+            return NoContent();
+        }
+    }
+}

--- a/src/EcommerceAPI.API/Controllers/OrdersController.cs
+++ b/src/EcommerceAPI.API/Controllers/OrdersController.cs
@@ -1,0 +1,98 @@
+using ecommerceAPI.src.EcommerceAPI.Application.DTOs;
+using ecommerceAPI.src.EcommerceAPI.Application.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using System.Security.Claims;
+
+namespace ecommerceAPI.src.EcommerceAPI.API.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    [Authorize]
+    public class OrdersController : ControllerBase
+    {
+        private readonly IOrderService _orderService;
+
+        public OrdersController(IOrderService orderService)
+        {
+            _orderService = orderService;
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> GetOrdersForUser()
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var orders = await _orderService.GetOrdersByUserAsync(userId);
+            return Ok(orders);
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetOrderById(Guid id)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var order = await _orderService.GetOrderByIdAsync(id, userId);
+            if (order == null)
+            {
+                return NotFound();
+            }
+            return Ok(order);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> CreateOrder([FromBody] CreateOrderDto orderDto)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var createdOrder = await _orderService.CreateOrderAsync(userId, orderDto);
+            return CreatedAtAction(nameof(GetOrderById), new { id = createdOrder.Id }, createdOrder);
+        }
+
+        [HttpPut("{id}")]
+        public async Task<IActionResult> UpdateOrder(Guid id, [FromBody] UpdateOrderDto orderDto)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var updated = await _orderService.UpdateOrderAsync(id, userId, orderDto);
+            if (!updated)
+            {
+                return NotFound();
+            }
+            return NoContent();
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> DeleteOrder(Guid id)
+        {
+            var userIdValue = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userIdValue == null || !Guid.TryParse(userIdValue, out var userId))
+            {
+                return Unauthorized("Invalid token.");
+            }
+
+            var deleted = await _orderService.DeleteOrderAsync(id, userId);
+            if (!deleted)
+            {
+                return NotFound();
+            }
+            return NoContent();
+        }
+    }
+}

--- a/src/EcommerceAPI.Application/DTOs/OrderDto.cs
+++ b/src/EcommerceAPI.Application/DTOs/OrderDto.cs
@@ -1,0 +1,21 @@
+namespace ecommerceAPI.src.EcommerceAPI.Application.DTOs
+{
+    public class OrderDto
+    {
+        public Guid Id { get; set; }
+        public DateTime OrderDate { get; set; }
+        public decimal TotalAmount { get; set; }
+        public string Status { get; set; } = string.Empty;
+        public IEnumerable<OrderItemDto> Items { get; set; } = new List<OrderItemDto>();
+    }
+
+    public class CreateOrderDto
+    {
+        public IEnumerable<CreateOrderItemDto> Items { get; set; } = new List<CreateOrderItemDto>();
+    }
+
+    public class UpdateOrderDto
+    {
+        public string Status { get; set; } = string.Empty;
+    }
+}

--- a/src/EcommerceAPI.Application/DTOs/OrderItemDto.cs
+++ b/src/EcommerceAPI.Application/DTOs/OrderItemDto.cs
@@ -1,0 +1,24 @@
+namespace ecommerceAPI.src.EcommerceAPI.Application.DTOs
+{
+    public class OrderItemDto
+    {
+        public Guid Id { get; set; }
+        public Guid ProductId { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+        public decimal TotalPrice { get; set; }
+    }
+
+    public class CreateOrderItemDto
+    {
+        public Guid ProductId { get; set; }
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+    }
+
+    public class UpdateOrderItemDto
+    {
+        public int Quantity { get; set; }
+        public decimal UnitPrice { get; set; }
+    }
+}

--- a/src/EcommerceAPI.Application/Interfaces/IOrderItemService.cs
+++ b/src/EcommerceAPI.Application/Interfaces/IOrderItemService.cs
@@ -1,0 +1,13 @@
+using ecommerceAPI.src.EcommerceAPI.Application.DTOs;
+
+namespace ecommerceAPI.src.EcommerceAPI.Application.Interfaces
+{
+    public interface IOrderItemService
+    {
+        Task<IEnumerable<OrderItemDto>> GetItemsByOrderIdAsync(Guid orderId, Guid userId);
+        Task<OrderItemDto?> GetItemByIdAsync(Guid id, Guid userId);
+        Task<OrderItemDto> AddItemAsync(Guid orderId, Guid userId, CreateOrderItemDto orderItemDto);
+        Task<bool> UpdateItemAsync(Guid id, Guid userId, UpdateOrderItemDto orderItemDto);
+        Task<bool> DeleteItemAsync(Guid id, Guid userId);
+    }
+}

--- a/src/EcommerceAPI.Application/Interfaces/IOrderService.cs
+++ b/src/EcommerceAPI.Application/Interfaces/IOrderService.cs
@@ -1,0 +1,13 @@
+using ecommerceAPI.src.EcommerceAPI.Application.DTOs;
+
+namespace ecommerceAPI.src.EcommerceAPI.Application.Interfaces
+{
+    public interface IOrderService
+    {
+        Task<IEnumerable<OrderDto>> GetOrdersByUserAsync(Guid userId);
+        Task<OrderDto?> GetOrderByIdAsync(Guid id, Guid userId);
+        Task<OrderDto> CreateOrderAsync(Guid userId, CreateOrderDto orderDto);
+        Task<bool> UpdateOrderAsync(Guid id, Guid userId, UpdateOrderDto orderDto);
+        Task<bool> DeleteOrderAsync(Guid id, Guid userId);
+    }
+}

--- a/src/EcommerceAPI.Application/Mapping/MappingProfile.cs
+++ b/src/EcommerceAPI.Application/Mapping/MappingProfile.cs
@@ -39,6 +39,23 @@ namespace ecommerceAPI.src.EcommerceAPI.Application.Mapping
                 .ForMember(dest => dest.PasswordHash, opt => opt.Ignore())
                 .ReverseMap();
 
+            CreateMap<Order, OrderDto>()
+                .ReverseMap()
+                .ForMember(dest => dest.Items, opt => opt.Ignore());
+            CreateMap<CreateOrderDto, Order>()
+                .ForMember(dest => dest.Items, opt => opt.Ignore())
+                .ReverseMap();
+            CreateMap<UpdateOrderDto, Order>()
+                .ForMember(dest => dest.Items, opt => opt.Ignore())
+                .ReverseMap();
+
+            CreateMap<OrderItem, OrderItemDto>()
+                .ReverseMap();
+            CreateMap<CreateOrderItemDto, OrderItem>()
+                .ReverseMap();
+            CreateMap<UpdateOrderItemDto, OrderItem>()
+                .ReverseMap();
+
 
         }
     }

--- a/src/EcommerceAPI.Application/Services/OrderItemService.cs
+++ b/src/EcommerceAPI.Application/Services/OrderItemService.cs
@@ -1,0 +1,122 @@
+using AutoMapper;
+using ecommerceAPI.src.EcommerceAPI.Application.DTOs;
+using ecommerceAPI.src.EcommerceAPI.Application.Interfaces;
+using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
+using ecommerceAPI.src.EcommerceAPI.Domain.Repositories;
+using System.Linq;
+
+namespace ecommerceAPI.src.EcommerceAPI.Application.Services
+{
+    public class OrderItemService : IOrderItemService
+    {
+        private readonly IOrderRepository _orderRepository;
+        private readonly IOrderItemRepository _orderItemRepository;
+        private readonly IMapper _mapper;
+
+        public OrderItemService(IOrderRepository orderRepository, IOrderItemRepository orderItemRepository, IMapper mapper)
+        {
+            _orderRepository = orderRepository;
+            _orderItemRepository = orderItemRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<OrderItemDto> AddItemAsync(Guid orderId, Guid userId, CreateOrderItemDto orderItemDto)
+        {
+            var order = await _orderRepository.GetByIdAsync(orderId);
+            if (order == null || order.UserId != userId)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
+            var item = new OrderItem
+            {
+                Id = Guid.NewGuid(),
+                OrderId = orderId,
+                ProductId = orderItemDto.ProductId,
+                Quantity = orderItemDto.Quantity,
+                UnitPrice = orderItemDto.UnitPrice,
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow
+            };
+
+            var createdItem = await _orderItemRepository.AddAsync(item);
+
+            order.TotalAmount += item.UnitPrice * item.Quantity;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _orderRepository.UpdateAsync(order);
+
+            return _mapper.Map<OrderItemDto>(createdItem);
+        }
+
+        public async Task<bool> DeleteItemAsync(Guid id, Guid userId)
+        {
+            var item = await _orderItemRepository.GetByIdAsync(id);
+            if (item == null)
+            {
+                return false;
+            }
+            var order = await _orderRepository.GetByIdAsync(item.OrderId);
+            if (order == null || order.UserId != userId)
+            {
+                return false;
+            }
+
+            await _orderItemRepository.DeleteAsync(id);
+            order.TotalAmount -= item.UnitPrice * item.Quantity;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _orderRepository.UpdateAsync(order);
+            return true;
+        }
+
+        public async Task<OrderItemDto?> GetItemByIdAsync(Guid id, Guid userId)
+        {
+            var item = await _orderItemRepository.GetByIdAsync(id);
+            if (item == null)
+            {
+                return null;
+            }
+            var order = await _orderRepository.GetByIdAsync(item.OrderId);
+            if (order == null || order.UserId != userId)
+            {
+                return null;
+            }
+            return _mapper.Map<OrderItemDto>(item);
+        }
+
+        public async Task<IEnumerable<OrderItemDto>> GetItemsByOrderIdAsync(Guid orderId, Guid userId)
+        {
+            var order = await _orderRepository.GetByIdAsync(orderId);
+            if (order == null || order.UserId != userId)
+            {
+                return Enumerable.Empty<OrderItemDto>();
+            }
+            var items = await _orderItemRepository.GetItemsByOrderIdAsync(orderId);
+            return _mapper.Map<IEnumerable<OrderItemDto>>(items);
+        }
+
+        public async Task<bool> UpdateItemAsync(Guid id, Guid userId, UpdateOrderItemDto orderItemDto)
+        {
+            var item = await _orderItemRepository.GetByIdAsync(id);
+            if (item == null)
+            {
+                return false;
+            }
+            var order = await _orderRepository.GetByIdAsync(item.OrderId);
+            if (order == null || order.UserId != userId)
+            {
+                return false;
+            }
+
+            order.TotalAmount -= item.UnitPrice * item.Quantity;
+            item.Quantity = orderItemDto.Quantity;
+            item.UnitPrice = orderItemDto.UnitPrice;
+            item.UpdatedAt = DateTime.UtcNow;
+            await _orderItemRepository.UpdateAsync(item);
+            order.TotalAmount += item.UnitPrice * item.Quantity;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _orderRepository.UpdateAsync(order);
+            return true;
+        }
+    }
+}

--- a/src/EcommerceAPI.Application/Services/OrderService.cs
+++ b/src/EcommerceAPI.Application/Services/OrderService.cs
@@ -1,0 +1,88 @@
+using AutoMapper;
+using ecommerceAPI.src.EcommerceAPI.Application.DTOs;
+using ecommerceAPI.src.EcommerceAPI.Application.Interfaces;
+using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
+using ecommerceAPI.src.EcommerceAPI.Domain.Repositories;
+using System.Linq;
+
+namespace ecommerceAPI.src.EcommerceAPI.Application.Services
+{
+    public class OrderService : IOrderService
+    {
+        private readonly IOrderRepository _orderRepository;
+        private readonly IMapper _mapper;
+
+        public OrderService(IOrderRepository orderRepository, IMapper mapper)
+        {
+            _orderRepository = orderRepository;
+            _mapper = mapper;
+        }
+
+        public async Task<OrderDto> CreateOrderAsync(Guid userId, CreateOrderDto orderDto)
+        {
+            var order = new Order
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                OrderDate = DateTime.UtcNow,
+                Status = "Pending",
+                IsActive = true,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                Items = orderDto.Items.Select(item => new OrderItem
+                {
+                    Id = Guid.NewGuid(),
+                    ProductId = item.ProductId,
+                    Quantity = item.Quantity,
+                    UnitPrice = item.UnitPrice,
+                    IsActive = true,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                }).ToList()
+            };
+            order.TotalAmount = order.Items.Sum(i => i.UnitPrice * i.Quantity);
+            var createdOrder = await _orderRepository.AddAsync(order);
+            return _mapper.Map<OrderDto>(createdOrder);
+        }
+
+        public async Task<bool> DeleteOrderAsync(Guid id, Guid userId)
+        {
+            var order = await _orderRepository.GetByIdAsync(id);
+            if (order == null || order.UserId != userId)
+            {
+                return false;
+            }
+            await _orderRepository.DeleteAsync(id);
+            return true;
+        }
+
+        public async Task<OrderDto?> GetOrderByIdAsync(Guid id, Guid userId)
+        {
+            var order = await _orderRepository.GetByIdAsync(id);
+            if (order == null || order.UserId != userId)
+            {
+                return null;
+            }
+            return _mapper.Map<OrderDto>(order);
+        }
+
+        public async Task<IEnumerable<OrderDto>> GetOrdersByUserAsync(Guid userId)
+        {
+            var orders = await _orderRepository.GetOrdersByUserAsync(userId);
+            return _mapper.Map<IEnumerable<OrderDto>>(orders);
+        }
+
+        public async Task<bool> UpdateOrderAsync(Guid id, Guid userId, UpdateOrderDto orderDto)
+        {
+            var order = await _orderRepository.GetByIdAsync(id);
+            if (order == null || order.UserId != userId)
+            {
+                return false;
+            }
+            order.Status = orderDto.Status;
+            order.UpdatedAt = DateTime.UtcNow;
+            await _orderRepository.UpdateAsync(order);
+            return true;
+        }
+    }
+}

--- a/src/EcommerceAPI.Domain/Repositories/IOrderItemRepository.cs
+++ b/src/EcommerceAPI.Domain/Repositories/IOrderItemRepository.cs
@@ -1,0 +1,14 @@
+using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
+
+namespace ecommerceAPI.src.EcommerceAPI.Domain.Repositories
+{
+    public interface IOrderItemRepository
+    {
+        Task<IEnumerable<OrderItem>> GetItemsByOrderIdAsync(Guid orderId);
+        Task<OrderItem?> GetByIdAsync(Guid id);
+        Task<OrderItem> AddAsync(OrderItem item);
+        Task UpdateAsync(OrderItem item);
+        Task DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+    }
+}

--- a/src/EcommerceAPI.Domain/Repositories/IOrderRepository.cs
+++ b/src/EcommerceAPI.Domain/Repositories/IOrderRepository.cs
@@ -1,0 +1,15 @@
+using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
+
+namespace ecommerceAPI.src.EcommerceAPI.Domain.Repositories
+{
+    public interface IOrderRepository
+    {
+        Task<IEnumerable<Order>> GetAllAsync();
+        Task<IEnumerable<Order>> GetOrdersByUserAsync(Guid userId);
+        Task<Order?> GetByIdAsync(Guid id);
+        Task<Order> AddAsync(Order order);
+        Task UpdateAsync(Order order);
+        Task DeleteAsync(Guid id);
+        Task<bool> ExistsAsync(Guid id);
+    }
+}

--- a/src/EcommerceAPI.Persistence/Data/EcommerceDbContext.cs
+++ b/src/EcommerceAPI.Persistence/Data/EcommerceDbContext.cs
@@ -11,7 +11,11 @@ namespace ecommerceAPI.src.EcommerceAPI.Persistence.Data
 
         public DbSet<Category> Categories { get; set; }
         public DbSet<Product> Products { get; set; }
-        public DbSet<User> Users { get; set; } 
+        public DbSet<User> Users { get; set; }
+        public DbSet<Order> Orders { get; set; }
+        public DbSet<OrderItem> OrderItems { get; set; }
+        public DbSet<Payment> Payments { get; set; }
+        public DbSet<Shipping> Shippings { get; set; }
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);  

--- a/src/EcommerceAPI.Persistence/Repositories/OrderItemRepository.cs
+++ b/src/EcommerceAPI.Persistence/Repositories/OrderItemRepository.cs
@@ -1,0 +1,58 @@
+using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
+using ecommerceAPI.src.EcommerceAPI.Domain.Repositories;
+using ecommerceAPI.src.EcommerceAPI.Persistence.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace ecommerceAPI.src.EcommerceAPI.Persistence.Repositories
+{
+    public class OrderItemRepository : IOrderItemRepository
+    {
+        private readonly EcommerceDbContext _db;
+
+        public OrderItemRepository(EcommerceDbContext context)
+        {
+            _db = context;
+        }
+
+        public async Task<OrderItem> AddAsync(OrderItem item)
+        {
+            await _db.OrderItems.AddAsync(item);
+            await _db.SaveChangesAsync();
+            return item;
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            await _db.OrderItems
+                .Where(i => i.Id == id)
+                .ExecuteDeleteAsync();
+        }
+
+        public Task<bool> ExistsAsync(Guid id)
+        {
+            return _db.OrderItems
+                .AnyAsync(i => i.Id == id && i.IsActive);
+        }
+
+        public async Task<OrderItem?> GetByIdAsync(Guid id)
+        {
+            return await _db.OrderItems
+                .Where(i => i.Id == id && i.IsActive)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<OrderItem>> GetItemsByOrderIdAsync(Guid orderId)
+        {
+            return await _db.OrderItems
+                .Where(i => i.OrderId == orderId && i.IsActive)
+                .ToListAsync();
+        }
+
+        public async Task UpdateAsync(OrderItem item)
+        {
+            item.UpdatedAt = DateTime.UtcNow;
+            _db.OrderItems.Update(item);
+            await _db.SaveChangesAsync();
+        }
+    }
+}

--- a/src/EcommerceAPI.Persistence/Repositories/OrderRepository.cs
+++ b/src/EcommerceAPI.Persistence/Repositories/OrderRepository.cs
@@ -1,0 +1,70 @@
+using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
+using ecommerceAPI.src.EcommerceAPI.Domain.Repositories;
+using ecommerceAPI.src.EcommerceAPI.Persistence.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace ecommerceAPI.src.EcommerceAPI.Persistence.Repositories
+{
+    public class OrderRepository : IOrderRepository
+    {
+        private readonly EcommerceDbContext _db;
+
+        public OrderRepository(EcommerceDbContext context)
+        {
+            _db = context;
+        }
+
+        public async Task<Order> AddAsync(Order order)
+        {
+            await _db.Orders.AddAsync(order);
+            await _db.SaveChangesAsync();
+            return order;
+        }
+
+        public async Task DeleteAsync(Guid id)
+        {
+            await _db.Orders
+                .Where(o => o.Id == id)
+                .ExecuteDeleteAsync();
+        }
+
+        public Task<bool> ExistsAsync(Guid id)
+        {
+            return _db.Orders
+                .AnyAsync(o => o.Id == id && o.IsActive);
+        }
+
+        public async Task<IEnumerable<Order>> GetAllAsync()
+        {
+            return await _db.Orders
+                .Where(o => o.IsActive)
+                .Include(o => o.Items)
+                .OrderByDescending(o => o.OrderDate)
+                .ToListAsync();
+        }
+
+        public async Task<Order?> GetByIdAsync(Guid id)
+        {
+            return await _db.Orders
+                .Where(o => o.Id == id && o.IsActive)
+                .Include(o => o.Items)
+                .FirstOrDefaultAsync();
+        }
+
+        public async Task<IEnumerable<Order>> GetOrdersByUserAsync(Guid userId)
+        {
+            return await _db.Orders
+                .Where(o => o.UserId == userId && o.IsActive)
+                .Include(o => o.Items)
+                .OrderByDescending(o => o.OrderDate)
+                .ToListAsync();
+        }
+
+        public async Task UpdateAsync(Order order)
+        {
+            order.UpdatedAt = DateTime.UtcNow;
+            _db.Orders.Update(order);
+            await _db.SaveChangesAsync();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add order and order item controllers using JWT claims for user ID
- implement order/order item repositories, services, DTOs, and mappings
- register new services and DbSets for orders and items

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68abd4cc600c8326a6dc7660a92c0d8a