### PR TITLE
Enable response caching for categories

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -24,7 +24,8 @@ Console.WriteLine("DefaultConnection => " +
 
 builder.Services.AddAutoMapper(typeof(MappingProfile));
 
-builder.Services.AddControllers(); 
+builder.Services.AddControllers();
+builder.Services.AddResponseCaching();
 
 builder.Services.AddDbContext<EcommerceDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("DefaultConnection")));
@@ -120,6 +121,7 @@ app.MapGet("/", () => "Hola desde Ecommerce API en Docker con Swagger");
 
 app.UseCors("AllowAll");
 app.UseHttpsRedirection();
+app.UseResponseCaching();
 app.UseAuthentication();
 app.UseAuthorization();
 

--- a/src/EcommerceAPI.API/Controllers/CategoriesController.cs
+++ b/src/EcommerceAPI.API/Controllers/CategoriesController.cs
@@ -19,6 +19,7 @@ namespace ecommerceAPI.src.EcommerceAPI.API.Controllers
         }
         [HttpGet]
 
+        [ResponseCache(Duration = 10)]
         public async Task<ActionResult<IEnumerable<CategoryDto>>> GetAllCategories()
         {
             var categories = await _categoryService.GetAllCategoriesAsync(); 


### PR DESCRIPTION
## Summary
- enable response caching services and middleware
- cache GetAllCategories responses for 10 seconds

## Testing
- `dotnet test` *(fails: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68abd64749dc832695556eb186f3adf1