### PR TITLE
Remove MapsterMapper dependency

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,7 +1,5 @@
 using ecommerceAPI.src.EcommerceAPI.Application.Mapping;
 using ecommerceAPI.src.EcommerceAPI.Persistence.Data;
-using Mapster;
-using MapsterMapper;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Identity;
 using ecommerceAPI.src.EcommerceAPI.Domain.Entities;
@@ -28,7 +26,6 @@ Console.WriteLine("DefaultConnection => " +
 
 // Add services to the container.
 
-builder.Services.AddMapster();
 MapsterConfig.RegisterMappings();
 
 builder.Services.AddControllers();

--- a/ecommerceAPI.csproj
+++ b/ecommerceAPI.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Asp.Versioning.Mvc" Version="8.1.0" />
     <PackageReference Include="Asp.Versioning.Mvc.ApiExplorer" Version="8.1.0" />
     <PackageReference Include="Mapster" Version="7.4.0" />
-    <PackageReference Include="MapsterMapper" Version="7.4.0" />
     <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
     <PackageReference Include="EntityFramework" Version="6.5.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />


### PR DESCRIPTION
## Summary
- remove the unused MapsterMapper package reference to avoid restore failures
- clean up Program.cs to stop registering Mapster DI services that were unused

## Testing
- not run (environment does not include dotnet SDK)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a87e0eaa08326bcb9753dc172da76)